### PR TITLE
Add WooCommerce Cyber label plugin

### DIFF
--- a/wp-content/plugins/woocommerce-cyber-label/assets/css/style.css
+++ b/wp-content/plugins/woocommerce-cyber-label/assets/css/style.css
@@ -1,0 +1,33 @@
+.wc-cyber-label {
+    display: inline-block;
+    background: linear-gradient(135deg, #00b4d8, #0077b6);
+    color: #fff;
+    font-size: 0.75rem;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    padding: 0.35em 0.75em;
+    border-radius: 999px;
+    box-shadow: 0 4px 10px rgba(0, 119, 182, 0.25);
+    margin-bottom: 0.75rem;
+}
+
+.woocommerce ul.products li.product .wc-cyber-label {
+    position: absolute;
+    top: 1rem;
+    left: 1rem;
+    z-index: 5;
+}
+
+.single-product .wc-cyber-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35em;
+}
+
+.single-product .summary .wc-cyber-label::before,
+.woocommerce ul.products li.product .wc-cyber-label::before {
+    content: '\f2dc';
+    font-family: 'dashicons';
+    font-size: 1em;
+}

--- a/wp-content/plugins/woocommerce-cyber-label/readme.txt
+++ b/wp-content/plugins/woocommerce-cyber-label/readme.txt
@@ -1,0 +1,26 @@
+=== WooCommerce Cyber Label ===
+Contributors: demo
+Tags: woocommerce, label, badge, cyber, products
+Requires at least: 5.0
+Tested up to: 6.4
+Requires PHP: 7.4
+Stable tag: 1.0.0
+License: GPLv2 or later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
+
+Plugin para añadir una etiqueta "Cyber" a los productos seleccionados de WooCommerce.
+
+== Descripción ==
+
+El plugin permite activar una etiqueta llamativa "Cyber" en productos individuales. La etiqueta se muestra en el catálogo y en la ficha del producto.
+
+== Instalación ==
+
+1. Copia la carpeta `woocommerce-cyber-label` en el directorio `wp-content/plugins/`.
+2. Activa el plugin desde el menú *Plugins* en WordPress.
+3. Edita un producto de WooCommerce y marca la casilla **Mostrar etiqueta "Cyber"** en la pestaña *General*.
+
+== Changelog ==
+
+= 1.0.0 =
+* Versión inicial.

--- a/wp-content/plugins/woocommerce-cyber-label/woocommerce-cyber-label.php
+++ b/wp-content/plugins/woocommerce-cyber-label/woocommerce-cyber-label.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * Plugin Name: WooCommerce Cyber Label
+ * Description: Adds a "Cyber" badge to selected WooCommerce products on catalog and single product pages.
+ * Version: 1.0.0
+ * Author: Demo Developer
+ * Text Domain: woocommerce-cyber-label
+ * Domain Path: /languages
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class WooCommerce_Cyber_Label {
+
+    const META_KEY = '_wc_cyber_label_enabled';
+
+    public function __construct() {
+        add_action( 'init', array( $this, 'load_textdomain' ) );
+        add_action( 'woocommerce_product_options_general_product_data', array( $this, 'add_product_field' ) );
+        add_action( 'woocommerce_admin_process_product_object', array( $this, 'save_product_field' ) );
+        add_action( 'woocommerce_before_shop_loop_item_title', array( $this, 'render_catalog_label' ), 5 );
+        add_action( 'woocommerce_single_product_summary', array( $this, 'render_single_label' ), 4 );
+        add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_assets' ) );
+    }
+
+    public function load_textdomain() {
+        load_plugin_textdomain( 'woocommerce-cyber-label', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
+    }
+
+    public function add_product_field() {
+        echo '<div class="options_group">';
+
+        woocommerce_wp_checkbox( array(
+            'id'          => self::META_KEY,
+            'label'       => __( 'Mostrar etiqueta "Cyber"', 'woocommerce-cyber-label' ),
+            'description' => __( 'Añade una etiqueta destacada "Cyber" en el catálogo y la página del producto.', 'woocommerce-cyber-label' ),
+        ) );
+
+        echo '</div>';
+    }
+
+    public function save_product_field( $product ) {
+        $enabled = isset( $_POST[ self::META_KEY ] ) ? 'yes' : 'no';
+        $product->update_meta_data( self::META_KEY, $enabled );
+    }
+
+    protected function is_label_enabled( $product ) {
+        if ( ! $product instanceof WC_Product ) {
+            $product = wc_get_product( $product );
+        }
+
+        if ( ! $product ) {
+            return false;
+        }
+
+        return 'yes' === $product->get_meta( self::META_KEY );
+    }
+
+    public function render_catalog_label() {
+        global $product;
+
+        if ( ! $product instanceof WC_Product ) {
+            return;
+        }
+
+        if ( ! $this->is_label_enabled( $product ) ) {
+            return;
+        }
+
+        echo $this->get_label_markup();
+    }
+
+    public function render_single_label() {
+        global $product;
+
+        if ( ! $product instanceof WC_Product ) {
+            return;
+        }
+
+        if ( ! $this->is_label_enabled( $product ) ) {
+            return;
+        }
+
+        echo $this->get_label_markup();
+    }
+
+    protected function get_label_markup() {
+        ob_start();
+        ?>
+        <span class="wc-cyber-label"><?php esc_html_e( 'Cyber', 'woocommerce-cyber-label' ); ?></span>
+        <?php
+        return ob_get_clean();
+    }
+
+    public function enqueue_assets() {
+        if ( ! class_exists( 'WooCommerce' ) ) {
+            return;
+        }
+
+        $style_path = plugin_dir_path( __FILE__ ) . 'assets/css/style.css';
+
+        if ( file_exists( $style_path ) ) {
+            wp_enqueue_style(
+                'woocommerce-cyber-label',
+                plugin_dir_url( __FILE__ ) . 'assets/css/style.css',
+                array(),
+                filemtime( $style_path )
+            );
+        }
+    }
+}
+
+new WooCommerce_Cyber_Label();


### PR DESCRIPTION
## Summary
- add a WooCommerce plugin that allows enabling a "Cyber" badge on selected products
- render the badge on catalog and single product pages with custom styling
- document installation and usage instructions in a plugin readme

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d7447b567c832286fddab8d15f02f2